### PR TITLE
Update `dragon_baseline` dependency

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -5,6 +5,6 @@ wholeslidedata==0.0.15
 tqdm
 matplotlib
 picai_prep>=2.1.13
-dragon_baseline>=0.4.4
+dragon_baseline>=0.4.6
 nltk
 numba

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ dill==0.3.8
     #   datasets
     #   evaluate
     #   multiprocess
-dragon-baseline==0.4.4
+dragon-baseline==0.4.6
     # via -r requirements.in
 evaluate==0.4.3
     # via dragon-baseline


### PR DESCRIPTION
The updated dragon baseline module fixes the issue with the `text_target` / `tagged_text_target`.